### PR TITLE
Refactor: MetricStore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "co.adhoclabs"
 
 name := "akka-http-contrib"
 
-version := "0.0.1"
+version := "0.0.2"
 
 scalaVersion := "2.11.8"
 

--- a/src/main/scala/co/adhoclabs/akka/http/contrib/stores/MetricStore.scala
+++ b/src/main/scala/co/adhoclabs/akka/http/contrib/stores/MetricStore.scala
@@ -30,5 +30,5 @@ trait MetricStore {
    */
   def incr(endpoint: ThrottleEndpoint, url: String): Unit
 
-  def reset(endpoint: ThrottleEndpoint, url: String): Unit
+  def set(endpoint: ThrottleEndpoint, url: String, count: Long)
 }

--- a/src/main/scala/co/adhoclabs/akka/http/contrib/stores/RedisMetricStore.scala
+++ b/src/main/scala/co/adhoclabs/akka/http/contrib/stores/RedisMetricStore.scala
@@ -1,6 +1,5 @@
 package co.adhoclabs.akka.http.contrib.stores
 
-import akka.http.scaladsl.model.HttpRequest
 import co.adhoclabs.akka.http.contrib.throttle.ThrottleEndpoint
 import com.redis.RedisClientPool
 
@@ -18,10 +17,10 @@ class RedisMetricStore(val redis: RedisClientPool) extends MetricStore {
     redis.withClient(_.get(key)).map(_.toLong).getOrElse(0)
   }
 
-  override def reset(endpoint: ThrottleEndpoint, url: String): Unit = {
+  override def set(endpoint: ThrottleEndpoint, url: String, count: Long): Unit = {
     val key = keyForEndpoint(endpoint, url)
     val expiration = (System.currentTimeMillis() + endpoint.expiration.window.toMillis) / 1000
-    redis.withClient(_.setex(key, expiration.toInt, 0))
+    redis.withClient(_.setex(key, expiration.toInt, count))
   }
 
   /**

--- a/src/test/scala/co/adhoclabs/akka/http/contrib/stores/RedisMetricStoreTest.scala
+++ b/src/test/scala/co/adhoclabs/akka/http/contrib/stores/RedisMetricStoreTest.scala
@@ -55,7 +55,7 @@ class RedisMetricStoreTest extends FunSuite
     val captor = ArgumentCaptor.forClass(classOf[RedisClient ⇒ Boolean])
     val expiration = ((System.currentTimeMillis() + getEndpoint.expiration.window.toMillis) / 1000).toInt
     when(redisClientMock.setex(key, expiration, 0)).thenReturn(true)
-    store.reset(getEndpoint, "/user/someUserId")
+    store.set(getEndpoint, "/user/someUserId", 0)
     verify(redisClientPoolMock, times(1)).withClient(captor.capture())
     captor.getValue.apply(redisClientMock)
     verify(redisClientMock, times(1)).setex(key, expiration, 0)


### PR DESCRIPTION
Replace the reset method by the set method.
The difference is that the set method can set the counter number
to any given number.
